### PR TITLE
Add jitter

### DIFF
--- a/golang.mk
+++ b/golang.mk
@@ -87,7 +87,7 @@ golang-test-deps:
 # arg1: pkg path
 define golang-test
 @echo "TESTING $(1)..."
-@go test -timeout 5s -v $(1)
+@go test -timeout 2s -v $(1)
 endef
 
 # golang-test-strict-deps is here for consistency

--- a/golang.mk
+++ b/golang.mk
@@ -87,7 +87,7 @@ golang-test-deps:
 # arg1: pkg path
 define golang-test
 @echo "TESTING $(1)..."
-@go test -timeout 1s -v $(1)
+@go test -timeout 5s -v $(1)
 endef
 
 # golang-test-strict-deps is here for consistency

--- a/rw_mutex.go
+++ b/rw_mutex.go
@@ -2,6 +2,7 @@ package lock
 
 import (
 	"fmt"
+	"math/rand"
 	"time"
 
 	"gopkg.in/mgo.v2"
@@ -62,7 +63,8 @@ func (m *RWMutex) Lock() error {
 			// but something for which we should maintain external documentation
 			return err
 		}
-		time.Sleep(m.SleepTime)
+		jitter := time.Duration(rand.Int63n(1000)) * time.Millisecond
+		time.Sleep(m.SleepTime + jitter)
 	}
 }
 
@@ -112,7 +114,8 @@ func (m *RWMutex) RLock() error {
 			// something for which we should maintain external documentation
 			return err
 		}
-		time.Sleep(m.SleepTime)
+		jitter := time.Duration(rand.Int63n(1000)) * time.Millisecond
+		time.Sleep(m.SleepTime + jitter)
 	}
 }
 


### PR DESCRIPTION
We're seeing high contention in mongo due to highly time-correlated
requests for the same lock. To relieve this pressure, we're adding a
jitter to sleep time of 0 to 1s. In the future, we should make this
range configurable.