### PR TITLE
Ding 1920

### DIFF
--- a/rw_mutex.go
+++ b/rw_mutex.go
@@ -3,6 +3,7 @@ package lock
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/rand"
 	"time"
 
@@ -78,7 +79,7 @@ func (m *RWMutex) tryToGetWriteLock() error {
 		writeLockQuery = bson.M{
 			"$or": []bson.M{
 				{"lockID": m.lockID},
-				{"lockID": m.districtID},
+				{"lockID": bson.M{"$regex": fmt.Sprintf("^%s", m.districtID)}},
 			},
 			"$and": []bson.M{emptyReaderQuery, emptyWriterQuery},
 		}
@@ -149,7 +150,7 @@ func (m *RWMutex) Unlock() error {
 		unlockQuery = bson.M{
 			"$or": []bson.M{
 				{"lockID": m.lockID},
-				{"lockID": m.districtID},
+				{"lockID": bson.M{"$regex": fmt.Sprintf("^%s", m.districtID)}},
 			},
 			"writer": m.clientID,
 		}
@@ -215,7 +216,7 @@ func (m *RWMutex) tryToGetReadLock(lock *mongoLock) error {
 		readLockQuery = bson.M{
 			"$or": []bson.M{
 				{"lockID": m.lockID},
-				{"lockID": m.districtID},
+				{"lockID": bson.M{"$regex": fmt.Sprintf("^%s", m.districtID)}},
 			},
 			"$and": []bson.M{emptyWriterQuery},
 		}
@@ -247,7 +248,7 @@ func (m *RWMutex) RUnlock() error {
 		unlockQuery = bson.M{
 			"$or": []bson.M{
 				{"lockID": m.lockID},
-				{"lockID": m.districtID},
+				{"lockID": bson.M{"$regex": fmt.Sprintf("^%s", m.districtID)}},
 			},
 			"readers": m.clientID,
 		}
@@ -273,7 +274,7 @@ func (m *RWMutex) findOrCreateLock() (*mongoLock, error) {
 	if m.checkBothLockTypes {
 		lockIDQuery = bson.M{"$or": []bson.M{
 			{"lockID": m.lockID},
-			{"lockID": m.districtID},
+			{"lockID": bson.M{"$regex": fmt.Sprintf("^%s", m.districtID)}},
 		}}
 	}
 

--- a/rw_mutex_lock_test.go
+++ b/rw_mutex_lock_test.go
@@ -100,7 +100,6 @@ func TestDistrictIDLockNewSuccess(t *testing.T) {
 		LockID:  districtID,
 		Writer:  clientID,
 		Readers: []string{},
-
 	}, mLock)
 }
 

--- a/rw_mutex_lock_test.go
+++ b/rw_mutex_lock_test.go
@@ -210,9 +210,9 @@ func TestDistrictIDLockWaitsForWriter(t *testing.T) {
 	go func() {
 		time.Sleep(time.Duration(10) * time.Millisecond)
 		var mLock mongoLock
-		c.FindOne(t, bson.M{"lockID": districtID}, options.FindOne(), &mLock)
+		c.FindOne(t, bson.M{"lockID": lockID}, options.FindOne(), &mLock)
 		assert.Equal(t, mongoLock{
-			LockID:  districtID,
+			LockID:  lockID,
 			Writer:  "client_2",
 			Readers: []string{},
 		}, mLock)
@@ -231,9 +231,9 @@ func TestDistrictIDLockWaitsForWriter(t *testing.T) {
 	require.NoError(t, err)
 
 	var mLock mongoLock
-	c.FindOne(t, bson.M{"lockID": districtID}, options.FindOne(), &mLock)
+	c.FindOne(t, bson.M{"lockID": lockID}, options.FindOne(), &mLock)
 	assert.Equal(t, mongoLock{
-		LockID:  districtID,
+		LockID:  lockID,
 		Writer:  clientID,
 		Readers: []string{},
 	}, mLock)
@@ -289,9 +289,9 @@ func TestDistrictIDLockWaitsForReader(t *testing.T) {
 	go func() {
 		time.Sleep(time.Duration(10) * time.Millisecond)
 		var mLock mongoLock
-		c.FindOne(t, bson.M{"lockID": districtID}, options.FindOne(), &mLock)
+		c.FindOne(t, bson.M{"lockID": lockID}, options.FindOne(), &mLock)
 		assert.Equal(t, mongoLock{
-			LockID:  districtID,
+			LockID:  lockID,
 			Writer:  "",
 			Readers: []string{"client_2"},
 		}, mLock)
@@ -309,9 +309,9 @@ func TestDistrictIDLockWaitsForReader(t *testing.T) {
 	require.NoError(t, err)
 
 	var mLock mongoLock
-	c.FindOne(t, bson.M{"lockID": districtID}, options.FindOne(), &mLock)
+	c.FindOne(t, bson.M{"lockID": lockID}, options.FindOne(), &mLock)
 	assert.Equal(t, mongoLock{
-		LockID:  districtID,
+		LockID:  lockID,
 		Writer:  clientID,
 		Readers: []string{},
 	}, mLock)
@@ -356,18 +356,18 @@ func TestDistrictIDLockReenter(t *testing.T) {
 	// enter first time
 	require.NoError(t, lock.Lock())
 	var mLock mongoLock
-	c.FindOne(t, bson.M{"lockID": districtID}, options.FindOne(), &mLock)
+	c.FindOne(t, bson.M{"lockID": lockID}, options.FindOne(), &mLock)
 	assert.Equal(t, mongoLock{
-		LockID:  districtID,
+		LockID:  lockID,
 		Writer:  clientID,
 		Readers: []string{},
 	}, mLock)
 
 	// re-enter
 	require.NoError(t, lock.Lock())
-	c.FindOne(t, bson.M{"lockID": districtID}, options.FindOne(), &mLock)
+	c.FindOne(t, bson.M{"lockID": lockID}, options.FindOne(), &mLock)
 	assert.Equal(t, mongoLock{
-		LockID:  districtID,
+		LockID:  lockID,
 		Writer:  clientID,
 		Readers: []string{},
 	}, mLock)
@@ -419,9 +419,9 @@ func TestTryDistrictIDLock(t *testing.T) {
 	require.NoError(t, lock.TryLock())
 
 	var mLock mongoLock
-	c.FindOne(t, bson.M{"lockID": districtID}, options.FindOne(), &mLock)
+	c.FindOne(t, bson.M{"lockID": lockID}, options.FindOne(), &mLock)
 	assert.Equal(t, mongoLock{
-		LockID:  districtID,
+		LockID:  lockID,
 		Writer:  clientID,
 		Readers: []string{},
 	}, mLock)

--- a/rw_mutex_rlock_test.go
+++ b/rw_mutex_rlock_test.go
@@ -187,7 +187,7 @@ func TestRLockMultipleReaders(t *testing.T) {
 func TestRDistrictIDLockMultipleReaders(t *testing.T) {
 	c := setupRWMutexTest(t)
 
-	firstLock := NewRWMutex(c.collection, districtID, "client_2", districtID, false)
+	firstLock := NewRWMutex(c.collection, districtID, "client_2", districtID, true)
 	err := firstLock.RLock()
 	require.NoError(t, err)
 
@@ -205,9 +205,9 @@ func TestRDistrictIDLockMultipleReaders(t *testing.T) {
 	require.NoError(t, err)
 
 	var mLock mongoLock
-	c.FindOne(t, bson.M{"lockID": districtID}, options.FindOne(), &mLock)
+	c.FindOne(t, bson.M{"lockID": lockID}, options.FindOne(), &mLock)
 	assert.Equal(t, mongoLock{
-		LockID:  districtID,
+		LockID:  lockID,
 		Readers: []string{"client_2", clientID},
 	}, mLock)
 }
@@ -251,18 +251,18 @@ func TestRDistrictIDLockReenter(t *testing.T) {
 	// get the read lock for the first time
 	require.NoError(t, lock.RLock())
 	var mLock mongoLock
-	c.FindOne(t, bson.M{"lockID": districtID}, options.FindOne(), &mLock)
+	c.FindOne(t, bson.M{"lockID": lockID}, options.FindOne(), &mLock)
 	assert.Equal(t, mongoLock{
-		LockID:  districtID,
+		LockID:  lockID,
 		Writer:  "",
 		Readers: []string{clientID},
 	}, mLock)
 
 	// check that grabbing it again yields same results
 	require.NoError(t, lock.RLock())
-	c.FindOne(t, bson.M{"lockID": districtID}, options.FindOne(), &mLock)
+	c.FindOne(t, bson.M{"lockID": lockID}, options.FindOne(), &mLock)
 	assert.Equal(t, mongoLock{
-		LockID:  districtID,
+		LockID:  lockID,
 		Writer:  "",
 		Readers: []string{clientID},
 	}, mLock)

--- a/rw_mutex_rlock_test.go
+++ b/rw_mutex_rlock_test.go
@@ -36,10 +36,10 @@ func TestRDistrictIDLockSuccess(t *testing.T) {
 	err := lock.RLock()
 
 	var mLock mongoLock
-	c.FindOne(t, bson.M{"lockID": districtID}, options.FindOne(), &mLock)
+	c.FindOne(t, bson.M{"lockID": lockID}, options.FindOne(), &mLock)
 	require.NoError(t, err)
 	assert.Equal(t, mongoLock{
-		LockID:  districtID,
+		LockID:  lockID,
 		Readers: []string{clientID},
 	}, mLock)
 }
@@ -117,16 +117,16 @@ func TestRLockWaitsForWriter(t *testing.T) {
 func TestRDistrictIDLockWaitsForWriter(t *testing.T) {
 	c := setupRWMutexTest(t)
 
-	firstLock := NewRWMutex(c.collection, districtID, "client_2", districtID, false)
+	firstLock := NewRWMutex(c.collection, districtID, "client_2", districtID, true)
 	err := firstLock.Lock()
 	require.NoError(t, err)
 	// check the lock after 10 milliseconds
 	go func() {
 		time.Sleep(time.Duration(10) * time.Millisecond)
 		var mLock mongoLock
-		c.FindOne(t, bson.M{"lockID": districtID}, options.FindOne(), &mLock)
+		c.FindOne(t, bson.M{"lockID": lockID}, options.FindOne(), &mLock)
 		assert.Equal(t, mongoLock{
-			LockID:  districtID,
+			LockID:  lockID,
 			Writer:  "client_2",
 			Readers: []string{},
 		}, mLock)
@@ -144,9 +144,9 @@ func TestRDistrictIDLockWaitsForWriter(t *testing.T) {
 	require.NoError(t, err)
 
 	var mLock mongoLock
-	c.FindOne(t, bson.M{"lockID": districtID}, options.FindOne(), &mLock)
+	c.FindOne(t, bson.M{"lockID": lockID}, options.FindOne(), &mLock)
 	assert.Equal(t, mongoLock{
-		LockID:  districtID,
+		LockID:  lockID,
 		Writer:  "",
 		Readers: []string{clientID},
 	}, mLock)

--- a/rw_mutex_rlock_test.go
+++ b/rw_mutex_rlock_test.go
@@ -67,9 +67,9 @@ func TestRDistrictIDLockNewSuccess(t *testing.T) {
 	require.NoError(t, err)
 
 	var mLock mongoLock
-	c.FindOne(t, bson.M{"lockID": districtID}, options.FindOne(), &mLock)
+	c.FindOne(t, bson.M{"lockID": lockID}, options.FindOne(), &mLock)
 	assert.Equal(t, mongoLock{
-		LockID:  districtID,
+		LockID:  lockID,
 		Readers: []string{clientID},
 	}, mLock)
 }

--- a/rw_mutex_rlock_test.go
+++ b/rw_mutex_rlock_test.go
@@ -27,6 +27,23 @@ func TestRLockSuccess(t *testing.T) {
 	}, mLock)
 }
 
+// TestDistrictIDRLockSuccess checks that RWMutex successfully acquires an existing lock not in contention
+func TestRDistrictIDLockSuccess(t *testing.T) {
+	c := setupRWMutexTest(t)
+	// Insert the base lock
+	c.InsertWithLockID(t, districtID)
+	lock := NewRWMutex(c.collection, lockID, clientID, districtID, true)
+	err := lock.RLock()
+
+	var mLock mongoLock
+	c.FindOne(t, bson.M{"lockID": districtID}, options.FindOne(), &mLock)
+	require.NoError(t, err)
+	assert.Equal(t, mongoLock{
+		LockID:  districtID,
+		Readers: []string{clientID},
+	}, mLock)
+}
+
 // TestRLockNewSuccess checks that RWMutex successfully acquires a new lock not in contention
 func TestRLockNewSuccess(t *testing.T) {
 	c := setupRWMutexTest(t)
@@ -42,11 +59,26 @@ func TestRLockNewSuccess(t *testing.T) {
 	}, mLock)
 }
 
+// TestRLockNewSuccess checks that RWMutex successfully acquires a new lock not in contention
+func TestRDistrictIDLockNewSuccess(t *testing.T) {
+	c := setupRWMutexTest(t)
+	lock := NewRWMutex(c.collection, lockID, clientID, districtID, true)
+	err := lock.RLock()
+	require.NoError(t, err)
+
+	var mLock mongoLock
+	c.FindOne(t, bson.M{"lockID": districtID}, options.FindOne(), &mLock)
+	assert.Equal(t, mongoLock{
+		LockID:  districtID,
+		Readers: []string{clientID},
+	}, mLock)
+}
+
 // TestRLockWaitsForWriter checks that RWMutex waitss until an existing writer has released the lock
 func TestRLockWaitsForWriter(t *testing.T) {
 	c := setupRWMutexTest(t)
 
-	firstLock := NewRWMutex(c.collection, lockID, "client_2", districtID, false)
+	firstLock := NewRWMutex(c.collection, lockID, "client_2", districtID, true)
 	err := firstLock.Lock()
 	require.NoError(t, err)
 	// check the lock after 10 milliseconds
@@ -67,7 +99,7 @@ func TestRLockWaitsForWriter(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	secondLock := NewRWMutex(c.collection, lockID, clientID, districtID, false)
+	secondLock := NewRWMutex(c.collection, lockID, clientID, districtID, true)
 	secondLock.SleepTime = time.Duration(5) * time.Millisecond
 	err = secondLock.RLock()
 	require.NoError(t, err)
@@ -76,6 +108,45 @@ func TestRLockWaitsForWriter(t *testing.T) {
 	c.FindOne(t, bson.M{"lockID": lockID}, options.FindOne(), &mLock)
 	assert.Equal(t, mongoLock{
 		LockID:  lockID,
+		Writer:  "",
+		Readers: []string{clientID},
+	}, mLock)
+}
+
+// TestRDistrictIDLockWaitsForWriter checks that RWMutex waitss until an existing writer has released the lock
+func TestRDistrictIDLockWaitsForWriter(t *testing.T) {
+	c := setupRWMutexTest(t)
+
+	firstLock := NewRWMutex(c.collection, districtID, "client_2", districtID, false)
+	err := firstLock.Lock()
+	require.NoError(t, err)
+	// check the lock after 10 milliseconds
+	go func() {
+		time.Sleep(time.Duration(10) * time.Millisecond)
+		var mLock mongoLock
+		c.FindOne(t, bson.M{"lockID": districtID}, options.FindOne(), &mLock)
+		assert.Equal(t, mongoLock{
+			LockID:  districtID,
+			Writer:  "client_2",
+			Readers: []string{},
+		}, mLock)
+	}()
+	// clear the lock after 100 milliseconds
+	go func() {
+		time.Sleep(time.Duration(100) * time.Millisecond)
+		err := firstLock.Unlock()
+		require.NoError(t, err)
+	}()
+
+	secondLock := NewRWMutex(c.collection, lockID, clientID, districtID, true)
+	secondLock.SleepTime = time.Duration(5) * time.Millisecond
+	err = secondLock.RLock()
+	require.NoError(t, err)
+
+	var mLock mongoLock
+	c.FindOne(t, bson.M{"lockID": districtID}, options.FindOne(), &mLock)
+	assert.Equal(t, mongoLock{
+		LockID:  districtID,
 		Writer:  "",
 		Readers: []string{clientID},
 	}, mLock)
@@ -111,13 +182,43 @@ func TestRLockMultipleReaders(t *testing.T) {
 	}, mLock)
 }
 
+// // TestRDistrictIDLockMultipleReaders checks that RWMutex.RLock acquires the lock if another client has the
+// // read lock
+func TestRDistrictIDLockMultipleReaders(t *testing.T) {
+	c := setupRWMutexTest(t)
+
+	firstLock := NewRWMutex(c.collection, districtID, "client_2", districtID, false)
+	err := firstLock.RLock()
+	require.NoError(t, err)
+
+	var firstMLock mongoLock
+	c.FindOne(t, bson.M{"lockID": districtID}, options.FindOne(), &firstMLock)
+	assert.Equal(t, mongoLock{
+		LockID:  districtID,
+		Writer:  "",
+		Readers: []string{"client_2"},
+	}, firstMLock)
+
+	secondLock := NewRWMutex(c.collection, lockID, clientID, districtID, true)
+	secondLock.SleepTime = time.Duration(5) * time.Millisecond
+	err = secondLock.RLock()
+	require.NoError(t, err)
+
+	var mLock mongoLock
+	c.FindOne(t, bson.M{"lockID": districtID}, options.FindOne(), &mLock)
+	assert.Equal(t, mongoLock{
+		LockID:  districtID,
+		Readers: []string{"client_2", clientID},
+	}, mLock)
+}
+
 // TestRLockReenter checks that RWMutex.lock reenters a write lock with the same client id
 func TestRLockReenter(t *testing.T) {
 	c := setupRWMutexTest(t)
 	// Insert the base lock
 	c.InsertWithLockID(t, lockID)
 
-	lock := NewRWMutex(c.collection, lockID, clientID, districtID, false)
+	lock := NewRWMutex(c.collection, lockID, clientID, districtID, true)
 
 	// get the read lock for the first time
 	require.NoError(t, lock.RLock())
@@ -134,6 +235,34 @@ func TestRLockReenter(t *testing.T) {
 	c.FindOne(t, bson.M{"lockID": lockID}, options.FindOne(), &mLock)
 	assert.Equal(t, mongoLock{
 		LockID:  lockID,
+		Writer:  "",
+		Readers: []string{clientID},
+	}, mLock)
+}
+
+// TestRDistrictIDLockReenter checks that RWMutex.lock reenters a write lock with the same client id
+func TestRDistrictIDLockReenter(t *testing.T) {
+	c := setupRWMutexTest(t)
+	// Insert the base lock
+	c.InsertWithLockID(t, districtID)
+
+	lock := NewRWMutex(c.collection, lockID, clientID, districtID, true)
+
+	// get the read lock for the first time
+	require.NoError(t, lock.RLock())
+	var mLock mongoLock
+	c.FindOne(t, bson.M{"lockID": districtID}, options.FindOne(), &mLock)
+	assert.Equal(t, mongoLock{
+		LockID:  districtID,
+		Writer:  "",
+		Readers: []string{clientID},
+	}, mLock)
+
+	// check that grabbing it again yields same results
+	require.NoError(t, lock.RLock())
+	c.FindOne(t, bson.M{"lockID": districtID}, options.FindOne(), &mLock)
+	assert.Equal(t, mongoLock{
+		LockID:  districtID,
 		Writer:  "",
 		Readers: []string{clientID},
 	}, mLock)

--- a/rw_mutex_rlock_test.go
+++ b/rw_mutex_rlock_test.go
@@ -15,7 +15,7 @@ func TestRLockSuccess(t *testing.T) {
 	c := setupRWMutexTest(t)
 	// Insert the base lock
 	c.InsertWithLockID(t, lockID)
-	lock := NewRWMutex(c.collection, lockID, clientID)
+	lock := NewRWMutex(c.collection, lockID, clientID, districtID, false)
 	err := lock.RLock()
 
 	var mLock mongoLock
@@ -30,7 +30,7 @@ func TestRLockSuccess(t *testing.T) {
 // TestRLockNewSuccess checks that RWMutex successfully acquires a new lock not in contention
 func TestRLockNewSuccess(t *testing.T) {
 	c := setupRWMutexTest(t)
-	lock := NewRWMutex(c.collection, lockID, clientID)
+	lock := NewRWMutex(c.collection, lockID, clientID, districtID, false)
 	err := lock.RLock()
 	require.NoError(t, err)
 
@@ -46,7 +46,7 @@ func TestRLockNewSuccess(t *testing.T) {
 func TestRLockWaitsForWriter(t *testing.T) {
 	c := setupRWMutexTest(t)
 
-	firstLock := NewRWMutex(c.collection, lockID, "client_2")
+	firstLock := NewRWMutex(c.collection, lockID, "client_2", districtID, false)
 	err := firstLock.Lock()
 	require.NoError(t, err)
 	// check the lock after 10 milliseconds
@@ -67,7 +67,7 @@ func TestRLockWaitsForWriter(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	secondLock := NewRWMutex(c.collection, lockID, clientID)
+	secondLock := NewRWMutex(c.collection, lockID, clientID, districtID, false)
 	secondLock.SleepTime = time.Duration(5) * time.Millisecond
 	err = secondLock.RLock()
 	require.NoError(t, err)
@@ -86,7 +86,7 @@ func TestRLockWaitsForWriter(t *testing.T) {
 func TestRLockMultipleReaders(t *testing.T) {
 	c := setupRWMutexTest(t)
 
-	firstLock := NewRWMutex(c.collection, lockID, "client_2")
+	firstLock := NewRWMutex(c.collection, lockID, "client_2", districtID, false)
 	err := firstLock.RLock()
 	require.NoError(t, err)
 
@@ -98,7 +98,7 @@ func TestRLockMultipleReaders(t *testing.T) {
 		Readers: []string{"client_2"},
 	}, firstMLock)
 
-	secondLock := NewRWMutex(c.collection, lockID, clientID)
+	secondLock := NewRWMutex(c.collection, lockID, clientID, districtID, false)
 	secondLock.SleepTime = time.Duration(5) * time.Millisecond
 	err = secondLock.RLock()
 	require.NoError(t, err)
@@ -117,7 +117,7 @@ func TestRLockReenter(t *testing.T) {
 	// Insert the base lock
 	c.InsertWithLockID(t, lockID)
 
-	lock := NewRWMutex(c.collection, lockID, clientID)
+	lock := NewRWMutex(c.collection, lockID, clientID, districtID, false)
 
 	// get the read lock for the first time
 	require.NoError(t, lock.RLock())

--- a/rw_mutex_runlock_test.go
+++ b/rw_mutex_runlock_test.go
@@ -12,7 +12,7 @@ import (
 // TestUnlockSuccess - RWMutex.Unlock releases the lock correctly
 func TestUnlockSuccess(t *testing.T) {
 	c := setupRWMutexTest(t)
-	lock := NewRWMutex(c.collection, lockID, clientID)
+	lock := NewRWMutex(c.collection, lockID, clientID, districtID, false)
 	require.NoError(t, lock.Lock())
 
 	err := lock.Unlock()
@@ -31,7 +31,7 @@ func TestUnlockSuccess(t *testing.T) {
 // TestUnlockNotHeld - RWMutex.Unlock returns an error if the client did not hold the lock
 func TestUnlockNotHeld(t *testing.T) {
 	c := setupRWMutexTest(t)
-	lock := NewRWMutex(c.collection, lockID, clientID)
+	lock := NewRWMutex(c.collection, lockID, clientID, districtID, false)
 
 	err := lock.Unlock()
 	assert.Error(t, err)

--- a/rw_mutex_runlock_test.go
+++ b/rw_mutex_runlock_test.go
@@ -12,7 +12,7 @@ import (
 // TestUnlockSuccess - RWMutex.Unlock releases the lock correctly
 func TestUnlockSuccess(t *testing.T) {
 	c := setupRWMutexTest(t)
-	lock := NewRWMutex(c.collection, lockID, clientID, districtID, false)
+	lock := NewRWMutex(c.collection, lockID, clientID, districtID, true)
 	require.NoError(t, lock.Lock())
 
 	err := lock.Unlock()
@@ -31,7 +31,7 @@ func TestUnlockSuccess(t *testing.T) {
 // TestUnlockNotHeld - RWMutex.Unlock returns an error if the client did not hold the lock
 func TestUnlockNotHeld(t *testing.T) {
 	c := setupRWMutexTest(t)
-	lock := NewRWMutex(c.collection, lockID, clientID, districtID, false)
+	lock := NewRWMutex(c.collection, lockID, clientID, districtID, true)
 
 	err := lock.Unlock()
 	assert.Error(t, err)

--- a/rw_mutex_unlock_test.go
+++ b/rw_mutex_unlock_test.go
@@ -12,11 +12,11 @@ import (
 // TestRUnlockSuccess - RWMutex.RUnlock releases the lock correctly
 func TestRUnlockSuccess(t *testing.T) {
 	c := setupRWMutexTest(t)
-	lock := NewRWMutex(c.collection, lockID, clientID)
+	lock := NewRWMutex(c.collection, lockID, clientID, districtID, false)
 	require.NoError(t, lock.RLock())
 
 	// add a second lock to check RWMutex only removes the read lock for its client
-	secondLock := NewRWMutex(c.collection, lockID, "client_2")
+	secondLock := NewRWMutex(c.collection, lockID, "client_2", districtID, false)
 	require.NoError(t, secondLock.RLock())
 
 	err := lock.RUnlock()
@@ -35,7 +35,7 @@ func TestRUnlockSuccess(t *testing.T) {
 // TestRUnlockNotHeld - RWMutex.RUnlock returns an error if the client did not hold the lock
 func TestRUnlockNotHeld(t *testing.T) {
 	c := setupRWMutexTest(t)
-	lock := NewRWMutex(c.collection, lockID, clientID)
+	lock := NewRWMutex(c.collection, lockID, clientID, districtID, false)
 
 	err := lock.RUnlock()
 	assert.Error(t, err)

--- a/rw_mutex_unlock_test.go
+++ b/rw_mutex_unlock_test.go
@@ -12,11 +12,11 @@ import (
 // TestRUnlockSuccess - RWMutex.RUnlock releases the lock correctly
 func TestRUnlockSuccess(t *testing.T) {
 	c := setupRWMutexTest(t)
-	lock := NewRWMutex(c.collection, lockID, clientID, districtID, false)
+	lock := NewRWMutex(c.collection, lockID, clientID, districtID, true)
 	require.NoError(t, lock.RLock())
 
 	// add a second lock to check RWMutex only removes the read lock for its client
-	secondLock := NewRWMutex(c.collection, lockID, "client_2", districtID, false)
+	secondLock := NewRWMutex(c.collection, lockID, "client_2", districtID, true)
 	require.NoError(t, secondLock.RLock())
 
 	err := lock.RUnlock()
@@ -35,7 +35,7 @@ func TestRUnlockSuccess(t *testing.T) {
 // TestRUnlockNotHeld - RWMutex.RUnlock returns an error if the client did not hold the lock
 func TestRUnlockNotHeld(t *testing.T) {
 	c := setupRWMutexTest(t)
-	lock := NewRWMutex(c.collection, lockID, clientID, districtID, false)
+	lock := NewRWMutex(c.collection, lockID, clientID, districtID, true)
 
 	err := lock.RUnlock()
 	assert.Error(t, err)


### PR DESCRIPTION
# JIRA
https://clever.atlassian.net/browse/DING-1920

# Overview
Adding a new boolean variable to the lock interface of this library.  If the variable is set to true when we check for an existing lock in addition to checking the lockID we check for an ID matching the district ID.  Using this approach when we try to acquire the lock we will be able to find new locks with the `districtID:type` format and old locks with the `districtID` format

# Testing
Adding a number of new unit tests so we are testing locks with a specific lockID and locks where the lockID is equivalent to districtID